### PR TITLE
Illustrate doNotStrip, since Gradle is getting more aggressive about it

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,6 +12,12 @@ android {
     versionName "1.5"
   }
 
+  // The native libraries from Block are already stripped, and contain security
+  // measures that can be disturbed if Gradle attempts to strip them again.
+  packagingOptions {
+    doNotStrip "*/*/libregister.so"
+  }
+
   dexOptions {
     preDexLibraries = true
     jumboMode = true


### PR DESCRIPTION
We already pre-strip our libraries, and it's sometimes a cause of errors when
Gradle stripping interacts badly with some of the security measures.