### PR TITLE
Upgrading RSDK to 1.5.6; also updating from ancient Grade and AGP to 7.0.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,7 +44,7 @@ repositories {
 }
 
 dependencies {
-  def readerSdkVersion = "1.5.5"
+  def readerSdkVersion = "1.5.6"
   // SQUARE_READER_SDK_APPLICATION_ID is defined in ./gradle.properties
   implementation "com.squareup.sdk.reader:reader-sdk-$SQUARE_READER_SDK_APPLICATION_ID:$readerSdkVersion"
   runtimeOnly "com.squareup.sdk.reader:reader-sdk-internals:$readerSdkVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     google()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.2.2'
+    classpath 'com.android.tools.build:gradle:7.0.4'
   }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Jul 08 16:37:05 CDT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Gradle 7.0.2 is about a year old, so we still aren't _bleeding_ edge, but some of our
third-party dependencies want a newer JVM than the old AGP 4.2 could handle.