### PR TITLE
Upgrade to Reader SDK 1.7.1, and upgrade to Android API 31.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
   defaultConfig {
     applicationId "com.example.readersdk"
     minSdkVersion 24
-    targetSdkVersion 30
+    targetSdkVersion 31
     multiDexEnabled true
     versionCode 1050
     versionName "1.5"
@@ -44,7 +44,7 @@ repositories {
 }
 
 dependencies {
-  def readerSdkVersion = "1.6.2"
+  def readerSdkVersion = "1.7.1"
   // SQUARE_READER_SDK_APPLICATION_ID is defined in ./gradle.properties
   implementation "com.squareup.sdk.reader:reader-sdk-$SQUARE_READER_SDK_APPLICATION_ID:$readerSdkVersion"
   runtimeOnly "com.squareup.sdk.reader:reader-sdk-internals:$readerSdkVersion"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.example.readersdk">
 
   <!-- This is needed to scan QR codes, not a requirement for Reader SDK. -->
@@ -6,6 +7,15 @@
 
   <uses-feature android:name="android.hardware.camera"/>
   <uses-feature android:name="android.hardware.camera.autofocus"/>
+
+  <!-- Developers who, contrary to Google Play Store recommendations, wish to stay
+       below Android API 31 should un-comment these lines:
+  <uses-permission tools:node="remove"
+       android:name="android.permission.BLUETOOTH_CONNECT" />
+  <uses-permission tools:node="remove"
+     android:name="android.permission.BLUETOOTH_SCAN"
+     android:usesPermissionFlags="neverForLocation"/>
+  -->
 
   <application
       android:name=".ExampleApplication"
@@ -16,6 +26,7 @@
       android:theme="@style/AppTheme">
     <activity
         android:name=".StartAuthorizeActivity"
+        android:exported="true"
         android:theme="@style/JewelTheme"/>
 
     <activity android:name=".ManualCodeEntryActivity"/>
@@ -26,6 +37,7 @@
 
     <activity
         android:name=".CheckoutActivity"
+        android:exported="true"
         android:theme="@style/JewelTheme">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>


### PR DESCRIPTION
Developers staying below API 31 should uncomment the removal of the new Bluetooth permissions in app/src/main/AndroidManifest.xml.