### PR TITLE
Release 1.7.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-  compileSdkVersion 31
+  compileSdkVersion 32
   buildToolsVersion "30.0.3"
   defaultConfig {
     applicationId "com.example.readersdk"
@@ -44,7 +44,7 @@ repositories {
 }
 
 dependencies {
-  def readerSdkVersion = "1.7.1"
+  def readerSdkVersion = "1.7.4"
   // SQUARE_READER_SDK_APPLICATION_ID is defined in ./gradle.properties
   implementation "com.squareup.sdk.reader:reader-sdk-$SQUARE_READER_SDK_APPLICATION_ID:$readerSdkVersion"
   runtimeOnly "com.squareup.sdk.reader:reader-sdk-internals:$readerSdkVersion"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,15 +8,6 @@
   <uses-feature android:name="android.hardware.camera"/>
   <uses-feature android:name="android.hardware.camera.autofocus"/>
 
-  <!-- Developers who, contrary to Google Play Store recommendations, wish to stay
-       below Android API 31 should un-comment these lines:
-  <uses-permission tools:node="remove"
-       android:name="android.permission.BLUETOOTH_CONNECT" />
-  <uses-permission tools:node="remove"
-     android:name="android.permission.BLUETOOTH_SCAN"
-     android:usesPermissionFlags="neverForLocation"/>
-  -->
-
   <application
       android:name=".ExampleApplication"
       android:allowBackup="true"


### PR DESCRIPTION
## Change log

- Fixed crash on Android 12+ (API 31+) when targeting API 30
- Slightly decreased SDK size
- Minimum compile SDK version is now 32